### PR TITLE
Fix: S3 ACLs and building Docker image from arm processor

### DIFF
--- a/bootstrap_files/AWS/terraform/buckets/data_bucket.tf
+++ b/bootstrap_files/AWS/terraform/buckets/data_bucket.tf
@@ -15,14 +15,12 @@
 #   }
 # }
 
-# resource "aws_s3_bucket_acl" "ge_data_bucket" {
-#   bucket = aws_s3_bucket.ge_data_bucket.id
-#   acl    = "private"
-# }
 
 # resource "aws_s3_bucket_public_access_block" "ge_data_bucket" {
-#   bucket = aws_s3_bucket.ge_data_bucket.id
-
-#   block_public_acls   = true
-#   block_public_policy = true
+# bucket = aws_s3_bucket.ge_data_bucket.id
+#
+# block_public_acls       = true
+# block_public_policy     = true
+# ignore_public_acls      = true
+# restrict_public_buckets = true
 # }

--- a/bootstrap_files/AWS/terraform/buckets/ge_buckets.tf
+++ b/bootstrap_files/AWS/terraform/buckets/ge_buckets.tf
@@ -10,16 +10,13 @@ resource "aws_s3_bucket" "ge_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "ge_bucket" {
-  bucket = aws_s3_bucket.ge_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_public_access_block" "ge_bucket" {
   bucket = aws_s3_bucket.ge_bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }
 
 # -------------------------------------------------------------
@@ -34,10 +31,6 @@ resource "aws_s3_bucket" "ge_site_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "ge_site_bucket" {
-  bucket = aws_s3_bucket.ge_site_bucket.id
-  acl    = "public-read"
-}
 
 resource "aws_s3_bucket_public_access_block" "ge_site_bucket" {
   bucket = aws_s3_bucket.ge_site_bucket.id

--- a/bootstrap_files/AWS/terraform/buckets/ge_buckets.tf
+++ b/bootstrap_files/AWS/terraform/buckets/ge_buckets.tf
@@ -35,11 +35,14 @@ resource "aws_s3_bucket" "ge_site_bucket" {
 resource "aws_s3_bucket_public_access_block" "ge_site_bucket" {
   bucket = aws_s3_bucket.ge_site_bucket.id
 
-  block_public_acls   = false
-  block_public_policy = false
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_policy" "allow_public_access" {
+  depends_on = [aws_s3_bucket_public_access_block.ge_site_bucket]
   bucket = aws_s3_bucket.ge_site_bucket.id
   policy = <<EOF
 {

--- a/bootstrap_files/AWS/terraform/lambda/lambda.tf
+++ b/bootstrap_files/AWS/terraform/lambda/lambda.tf
@@ -74,3 +74,37 @@ resource "aws_iam_role_policy_attachment" "validation_lambda_policy" {
   role       = aws_iam_role.validation_lambda_role.name
   policy_arn = aws_iam_policy.validation_lambda_policy.arn
 }
+
+
+# -------------------------------------------------------------
+# Lambda logging
+# -------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.validation_lambda.function_name}"
+  retention_in_days = 7
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_iam_policy" "function_logging_policy" {
+  name   = "function-logging-policy"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        Action : [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Effect : "Allow",
+        Resource : "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "function_logging_policy" {
+  role       = aws_iam_role.validation_lambda_role.name
+  policy_arn = aws_iam_policy.function_logging_policy.arn
+}

--- a/bootstrap_files/AWS/tutorial_files/terraform/buckets/data_bucket.tf
+++ b/bootstrap_files/AWS/tutorial_files/terraform/buckets/data_bucket.tf
@@ -10,14 +10,11 @@ resource "aws_s3_bucket" "ge_data_bucket" {
   }
 }
 
-resource "aws_s3_bucket_acl" "ge_data_bucket" {
-  bucket = aws_s3_bucket.ge_data_bucket.id
-  acl    = "private"
-}
-
 resource "aws_s3_bucket_public_access_block" "ge_data_bucket" {
   bucket = aws_s3_bucket.ge_data_bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/bootstrap_files/AWS/tutorial_files/terraform/lambda/lambda.tf
+++ b/bootstrap_files/AWS/tutorial_files/terraform/lambda/lambda.tf
@@ -76,3 +76,37 @@ resource "aws_iam_role_policy_attachment" "validation_lambda_policy" {
   role       = aws_iam_role.validation_lambda_role.name
   policy_arn = aws_iam_policy.validation_lambda_policy.arn
 }
+
+
+# -------------------------------------------------------------
+# Lambda logging
+# -------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "lambda_log_group" {
+  name              = "/aws/lambda/${aws_lambda_function.validation_lambda.function_name}"
+  retention_in_days = 7
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_iam_policy" "function_logging_policy" {
+  name   = "function-logging-policy"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        Action : [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ],
+        Effect : "Allow",
+        Resource : "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+resource "aws_iam_role_policy_attachment" "function_logging_policy" {
+  role       = aws_iam_role.validation_lambda_role.name
+  policy_arn = aws_iam_policy.function_logging_policy.arn
+}

--- a/docs/templates/AWS/ecr.sh
+++ b/docs/templates/AWS/ecr.sh
@@ -8,7 +8,7 @@ chmod 644 $(find . -type f)
 chmod 755 $(find . -type d)
 
 # Build image
-docker build -t {{ docker_image }} .
+docker build -t {{ docker_image }} . --platform=linux/amd64
 
 # Log into AWS and ECR
 aws ecr get-login-password --region {{ region }} | docker login --username AWS --password-stdin {{ ECR_endpoint }}


### PR DESCRIPTION
**What was the problem**
- New AWS [release](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) disabled bucket ACLs in favour of using IAM polices to secure s3.

- Validation lambda fails for invalid entrypoint when image is build from arm processor.

**What changed**
- Deleted bucket ACLs. 
- Turned on all Public access block for private s3, access granted through IAM.

- Added Lambda log group and logging policy
- Forced Docker to build image using platform `linux/amd64`. 